### PR TITLE
Update documentation

### DIFF
--- a/.github/workflows/gh-pages-ci-workflow.yml
+++ b/.github/workflows/gh-pages-ci-workflow.yml
@@ -5,9 +5,6 @@ on:
       - '.github/**'
     branches:
       - prod
-  pull_request:
-    branches:
-      - prod
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ For more details, consider to check our [**API documentation**][api-docs].
 
 [github-page-ci]: https://github.com/Devwarlt/pstk-core/actions?query=workflow%3A"GitHub+Pages+CI"
 [github-page-ci-dev-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg?branch=dev
-[github-page-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg?branch=prod
+[github-page-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg
 
 [dotnet-ci]: https://github.com/Devwarlt/pstk-core/actions?query=workflow%3A".NET+CI"
 [dotnet-ci-dev-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg?branch=dev
-[dotnet-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg?branch=prod
+[dotnet-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg
 
 [pstk-core-badge]: https://img.shields.io/nuget/v/PSTk.Core.svg?logo=nuget&style=plastic
 [pstk-core-downloads-badge]: https://img.shields.io/nuget/dt/PSTk.Core.svg?logo=nuget&style=plastic

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -45,11 +45,11 @@ For more details, consider to check our [**API documentation**][api-docs].
 
 [github-page-ci]: https://github.com/Devwarlt/pstk-core/actions?query=workflow%3A"GitHub+Pages+CI"
 [github-page-ci-dev-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg?branch=dev
-[github-page-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg?branch=prod
+[github-page-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg
 
 [dotnet-ci]: https://github.com/Devwarlt/pstk-core/actions?query=workflow%3A".NET+CI"
 [dotnet-ci-dev-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg?branch=dev
-[dotnet-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg?branch=prod
+[dotnet-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg
 
 [pstk-core-badge]: https://img.shields.io/nuget/v/PSTk.Core.svg?logo=nuget&style=plastic
 [pstk-core-downloads-badge]: https://img.shields.io/nuget/dt/PSTk.Core.svg?logo=nuget&style=plastic

--- a/docs/articles/async-procedure-and-async-procedure-pool.md
+++ b/docs/articles/async-procedure-and-async-procedure-pool.md
@@ -1,8 +1,9 @@
-# [Async Procedure][ref-1]
+# Async Procedure
 > Used for situations that require dependency between other procedure. Recommended to use it with **`AsyncProcedurePool`**.
 
-# [Async Procedure Pool][ref-2]
+# Async Procedure Pool
 > Handle **`AsyncProcedure(TInput)`** instances into pool of synchronous or asynchronous routines.
+
 ---
 
 **`Async Procedure`** can be used for procedures that require various operations (complex ones) and requires the output of all pending procedures to finish together. If a procedure breaks or stop working due an error then **`Async Procedure Pool`** will be set as invalid response flag type. See example below:
@@ -51,6 +52,3 @@ private static AsyncProcedureEventArgs<TInput> OnProcedureExecute(AsyncProcedure
 
 private static void OnProcedureError(string message) => Console.WriteLine($"An error occurred! -> message: {message}");
 ```
-
-[ref-1]: /CA/Threading/Tasks/Procedures/AsyncProcedure.cs
-[ref-2]: /CA/Threading/Tasks/Procedures/AsyncProcedurePool.cs

--- a/docs/articles/automated-restarter.md
+++ b/docs/articles/automated-restarter.md
@@ -1,5 +1,6 @@
-# [Automated Restarter][ref-1]
-> Creates an <see cref="InternalRoutine"/> adapted to handle events and execute a process when threshold is achieved.
+# Automated Restarter
+> Creates an `InternalRoutine` adapted class to handle events and execute a process when threshold is achieved.
+
 ---
 
 **`Automated Restarter`** can be used for procedures that check listeners with a countdown. Once an event listener matches with its timeout definition, then an action is invoked during process in parallel. Note that `Restarter` prefix on its name **doesn't** restart the application but could be used as one, see example below:
@@ -33,5 +34,3 @@ private static void RestartOperation() {
   _mre.Set();
 }
 ```
-
-[ref-1]: /CA/Threading/Tasks/AutomatedRestarter.cs

--- a/docs/articles/internal-routine.md
+++ b/docs/articles/internal-routine.md
@@ -1,5 +1,6 @@
-# [Internal Routine][ref-1]
+# Internal Routine
 > Used for synchronous or asynchronous routine.
+
 ---
 
 **`Internal Routine`** can be used for cyclic operations running in parallel as loop process, see example below:
@@ -48,5 +49,3 @@ private static void OnFinished(object sender, EventArgs args) {
   _mre.Set();
 }
 ```
-
-[ref-1]: /CA/Threading/Tasks/InternalRoutine.cs

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,11 +45,11 @@ For more details, consider to check our [**API documentation**][api-docs].
 
 [github-page-ci]: https://github.com/Devwarlt/pstk-core/actions?query=workflow%3A"GitHub+Pages+CI"
 [github-page-ci-dev-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg?branch=dev
-[github-page-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg?branch=prod
+[github-page-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/GitHub%20Pages%20CI/badge.svg
 
 [dotnet-ci]: https://github.com/Devwarlt/pstk-core/actions?query=workflow%3A".NET+CI"
 [dotnet-ci-dev-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg?branch=dev
-[dotnet-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg?branch=prod
+[dotnet-ci-prod-badge]: https://github.com/Devwarlt/pstk-core/workflows/.NET%20CI/badge.svg
 
 [pstk-core-badge]: https://img.shields.io/nuget/v/PSTk.Core.svg?logo=nuget&style=plastic
 [pstk-core-downloads-badge]: https://img.shields.io/nuget/dt/PSTk.Core.svg?logo=nuget&style=plastic


### PR DESCRIPTION
## :notebook_with_decorative_cover: Change log:
- [x] updated "GitHub Pages CI" to deploy only on PR or push events to branch `prod`;
- [x] updated not showing status badge for default branch, for ".NET CI" workflow;
- [x] removed invalid links on articles;
- [x] removed invalid tag declaration on article "Creating an automated restarter".